### PR TITLE
Corrected table of contents of v138

### DIFF
--- a/_posts/2020-02-02-campos20a.md
+++ b/_posts/2020-02-02-campos20a.md
@@ -22,7 +22,7 @@ cycles: false
 bibtex_author: de Campos, Cassio P.
 author:
 - given: Cassio P.
-  family: Campos
+  family: de Campos
 date: 2020-02-02
 address: 
 container-title: Proceedings of the 10th International Conference on Probabilistic

--- a/_posts/2020-02-02-ducamp20b.md
+++ b/_posts/2020-02-02-ducamp20b.md
@@ -32,7 +32,7 @@ tex_title: "An Efficient Low-Rank Tensors Representation for \r Algorithms in Co
 firstpage: 173
 lastpage: 184
 page: 173-184
-order: 00  
+order: 173  
 cycles: false
 bibtex_author: Ducamp, Gaspard and Bonnard, Philippe and Nouy, Anthony 
   and Wuillemin, Pierre-Henri

--- a/_posts/2020-02-02-ducamp20b.md
+++ b/_posts/2020-02-02-ducamp20b.md
@@ -29,8 +29,12 @@ id: ducamp20b
 month: 0
 tex_title: "An Efficient Low-Rank Tensors Representation for \r Algorithms in Complex
   Probabilistic Graphical Models"
+firstpage: 173
+lastpage: 184
+page: 173-184
+order: 00  
 cycles: false
-bibtex_author: Ducamp, Gaspard and Bonnard, Philippe and Nouy, Anthony pages = {173-184}
+bibtex_author: Ducamp, Gaspard and Bonnard, Philippe and Nouy, Anthony 
   and Wuillemin, Pierre-Henri
 author:
 - given: Gaspard

--- a/_posts/2020-02-02-dufraisse20a.md
+++ b/_posts/2020-02-02-dufraisse20a.md
@@ -28,7 +28,7 @@ tex_title: "Interactive Anomaly Detection in Mixed Tabular Data \r using Bayesia
 firstpage: 185
 lastpage: 196
 page: 185-196
-order: 00
+order: 185
 cycles: false
 bibtex_author: Dufraisse, Evan and Leray, Philippe and Nedellec, 
   Rapha\"el and Benkhelif, Tarek

--- a/_posts/2020-02-02-dufraisse20a.md
+++ b/_posts/2020-02-02-dufraisse20a.md
@@ -25,8 +25,12 @@ id: dufraisse20a
 month: 0
 tex_title: "Interactive Anomaly Detection in Mixed Tabular Data \r using Bayesian
   Networks"
+firstpage: 185
+lastpage: 196
+page: 185-196
+order: 00
 cycles: false
-bibtex_author: Dufraisse, Evan and Leray, Philippe and Nedellec, pages = {185-196},
+bibtex_author: Dufraisse, Evan and Leray, Philippe and Nedellec, 
   Rapha\"el and Benkhelif, Tarek
 author:
 - given: Evan

--- a/_posts/2020-02-02-markham20a.md
+++ b/_posts/2020-02-02-markham20a.md
@@ -1,6 +1,6 @@
 ---
 section: Software Demonstrations
-title: "\\textttMeDIL: A Python Package for Causal Modelling"
+title: "MeDIL: A Python Package for Causal Modelling"
 abstract: "  We present the \\texttt{MeDIL} Python package for causal modelling.\r
   Its current features focus on (i) non-linear unconditional pairwise independence
   testing,\r (ii) constraint-based causal structure learning, and\r (iii) learning
@@ -15,7 +15,7 @@ publisher: PMLR
 issn: 2640-3498
 id: markham20a
 month: 0
-tex_title: "\\texttt{MeDIL}: A Python Package for Causal Modelling"
+tex_title: "MeDIL: A Python Package for Causal Modelling"
 firstpage: 621
 lastpage: 624
 page: 621-624

--- a/_posts/2020-02-02-mielke20a.md
+++ b/_posts/2020-02-02-mielke20a.md
@@ -23,9 +23,12 @@ id: mielke20a
 month: 0
 tex_title: "Discovering cause-effect relationships in spatial systems \r with a known
   direction based on observational data"
+firstpage: 305
+lastpage: 316
+page: 305-316
+order: 00  
 cycles: false
-bibtex_author: Mielke, Konrad P and Claassen, Tom and Huijbregts, Mark A pages = {305-316},
-  J and Schipper, Aafke M and Heskes, Tom M
+bibtex_author: Mielke, Konrad P and Claassen, Tom and Huijbregts, Mark A J and Schipper, Aafke M and Heskes, Tom M
 author:
 - given: Konrad P
   family: Mielke

--- a/_posts/2020-02-02-mielke20a.md
+++ b/_posts/2020-02-02-mielke20a.md
@@ -26,7 +26,7 @@ tex_title: "Discovering cause-effect relationships in spatial systems \r with a 
 firstpage: 305
 lastpage: 316
 page: 305-316
-order: 00  
+order: 305  
 cycles: false
 bibtex_author: Mielke, Konrad P and Claassen, Tom and Huijbregts, Mark A J and Schipper, Aafke M and Heskes, Tom M
 author:

--- a/_posts/2020-02-02-nielsen20a.md
+++ b/_posts/2020-02-02-nielsen20a.md
@@ -8,6 +8,10 @@ issn: 2640-3498
 id: nielsen20a
 month: 0
 tex_title: Preface
+firstpage: 1
+lastpage: 4
+page: 1-4
+order: 1
 cycles: false
 bibtex_author: Nielsen, Thomas D. and Jaeger, Manfred
 author:

--- a/_posts/2020-02-02-tehrani20a.md
+++ b/_posts/2020-02-02-tehrani20a.md
@@ -29,7 +29,7 @@ tex_title: 'Bean Machine: A Declarative Probabilistic Programming Language For E
 firstpage: 485
 lastpage: 496
 page: 485-496
-order: 00
+order: 485
 cycles: false
 bibtex_author: Tehrani, Nazanin and Arora, Nimar S. and Li, Yucen Lily and Shah, Kinjal
   Divesh and Noursi, David and Tingley, Michael and Torabi, Narjes and 

--- a/_posts/2020-02-02-tehrani20a.md
+++ b/_posts/2020-02-02-tehrani20a.md
@@ -26,9 +26,13 @@ id: tehrani20a
 month: 0
 tex_title: 'Bean Machine: A Declarative Probabilistic Programming Language For Efficient
   Programmable Inference'
+firstpage: 485
+lastpage: 496
+page: 485-496
+order: 00
 cycles: false
 bibtex_author: Tehrani, Nazanin and Arora, Nimar S. and Li, Yucen Lily and Shah, Kinjal
-  Divesh and Noursi, David and Tingley, Michael and Torabi, Narjes and pages = {485-496},
+  Divesh and Noursi, David and Tingley, Michael and Torabi, Narjes and 
   Masouleh, Sepehr and Lippert, Eric and Meijer, Erik
 author:
 - given: Nazanin

--- a/_posts/2020-02-02-ventola20a.md
+++ b/_posts/2020-02-02-ventola20a.md
@@ -23,7 +23,7 @@ tex_title: Residual Sum-Product Networks
 firstpage: 545
 lastpage: 556
 page: 545-556
-order: 00
+order: 545
 cycles: false
 bibtex_author: Ventola, Fabrizio and Stelzner, Karl and Molina, 
   Alejandro and Kersting, Kristian

--- a/_posts/2020-02-02-ventola20a.md
+++ b/_posts/2020-02-02-ventola20a.md
@@ -20,8 +20,12 @@ issn: 2640-3498
 id: ventola20a
 month: 0
 tex_title: Residual Sum-Product Networks
+firstpage: 545
+lastpage: 556
+page: 545-556
+order: 00
 cycles: false
-bibtex_author: Ventola, Fabrizio and Stelzner, Karl and Molina, pages = {545-556},
+bibtex_author: Ventola, Fabrizio and Stelzner, Karl and Molina, 
   Alejandro and Kersting, Kristian
 author:
 - given: Fabrizio


### PR DESCRIPTION
Fixed formatting errors related to page numbers in the metadata of 7 papers. Also deleted a stray Latex formatting command from  the title of one paper.